### PR TITLE
API changes

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -26,6 +26,21 @@ and ('k, 'res) gens =
 
 type nonrec +'a list = 'a list = [] | (::) of 'a * 'a list
 
+let unlazy f =
+  Join (Primitive (fun _ -> Lazy.force f))
+let map gens f = Map (gens, f)
+
+let const x = map [] x
+let choose gens = Choose gens
+let option gen = Option gen
+let list gen = List gen
+let list1 gen = List1 gen
+let join ggen = Join ggen
+let with_printer pp gen = Print (pp, gen)
+
+let bind x f = join (map [x] f)
+
+
 let pp = Format.fprintf
 let pp_int ppf n = pp ppf "%d" n
 let pp_int32 ppf n = pp ppf "%s" (Int32.to_string n)
@@ -133,7 +148,7 @@ let bytes = Print (pp_string, Primitive (fun src ->
   let count = read_bytes 0 in
   Bytes.sub_string buf 0 count))
 
-let choose n state =
+let choose_int n state =
   assert (n > 0);
   if (n < 100) then
     read_byte state mod n
@@ -142,7 +157,7 @@ let choose n state =
   else
     Int64.(to_int (abs (rem (read_int64 state) (of_int n))))
 
-let range n = Print (pp_int, Primitive (choose n))
+let range n = Print (pp_int, Primitive (choose_int n))
 
 exception GenFailed of exn * Printexc.raw_backtrace * unit printer
 
@@ -160,7 +175,7 @@ let rec generate : type a . int -> state -> a gen -> a * unit printer =
          | small -> small
        else
          xs in
-     let n = choose (List.length gens) input in
+     let n = choose_int (List.length gens) input in
      let v, pv = generate size input (List.nth gens n) in
      v, fun ppf () -> pp ppf "#%d %a" n pv ()
   | Map ([], k) ->
@@ -408,7 +423,7 @@ let run_all_tests tests =
                        offset = 0; len = 0 } in
          let status =
            try run_test ~mode:(`Once state) ~silent:false ~verbose @@
-             List.nth tests (choose (List.length tests) state)
+             List.nth tests (choose_int (List.length tests) state)
            with 
            BadTest s -> BadInput s
          in

--- a/src/crowbar.mli
+++ b/src/crowbar.mli
@@ -2,25 +2,31 @@ type state
 
 type 'a printer = Format.formatter -> 'a -> unit
 
-type 'a gen =
-  | Const of 'a
-  | Choose of 'a gen list
-  | Map : ('f, 'a) gens * 'f -> 'a gen
-  | Option : 'a gen -> 'a option gen
-  | List : 'a gen -> 'a list gen
-  | List1 : 'a gen -> 'a list gen
-  | Join : 'a gen gen -> 'a gen
-  | Primitive of (state -> 'a)
-  | Print of 'a printer * 'a gen
+type 'a gen
 
-and ('k, 'res) gens =
+type ('k, 'res) gens =
   | [] : ('res, 'res) gens
   | (::) : 'a gen * ('k, 'res) gens -> ('a -> 'k, 'res) gens
-
 (* re-export stdlib's list
    We only want to override [] syntax in the argument to Map *)
 type nonrec +'a list = 'a list = [] | (::) of 'a * 'a list
 
+val map : ('f, 'a) gens -> 'f -> 'a gen
+
+val join : 'a gen gen -> 'a gen
+
+val bind : 'a gen -> ('a -> 'b gen) -> 'b gen
+
+val unlazy : 'a gen Lazy.t -> 'a gen
+
+val const : 'a -> 'a gen
+val choose : 'a gen list -> 'a gen
+
+val option : 'a gen -> 'a option gen
+val list : 'a gen -> 'a list gen
+val list1 : 'a gen -> 'a list gen
+
+val with_printer : 'a printer -> 'a gen -> 'a gen
 
 (* some builtin generators for primitive types *)
 


### PR DESCRIPTION
Makes `Crowbar.gen` an abstract type, using `Lazy` instead of constructors to handle recursive generators.

(the implementation in `crowbar.ml` should definitely be refactored, but I want to discuss the API first. see #3)

@yomimono opinions? this will break your charrua-core tests, but the fix is mostly changing uppercase to lowercase.