### PR TITLE
remove notty dependency

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,3 +1,3 @@
 true: bin_annot, debug
 <examples>: -traverse
-<src/**>: package(ocplib-endian), package(afl-persistent), package(notty.unix), package(str)
+<src/**>: package(ocplib-endian), package(afl-persistent), package(str)

--- a/opam
+++ b/opam
@@ -13,7 +13,6 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build & >= "0.7.4"}
-  "notty"
   "cmdliner"
   "ocplib-endian"
   "afl-persistent" {>= "1.1"}

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = ""
 version = "0.1"
-requires = "ocplib-endian notty.unix afl-persistent str"
+requires = "ocplib-endian afl-persistent str"
 archive(native) = "crowbar.cmxa"
 archive(byte) = "crowbar.cma"
 plugin(native) = "crowbar.cmxs"

--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -330,12 +330,8 @@ let src_of_seed seed =
   Random (Random.State.make seed)
 
 let run_test ~mode ~silent ?(verbose=false) (Test (name, gens, f)) =
-  let show_status_line ?(clear=false) ?(c=Notty.A.empty) stat =
-    let open Notty in
-    Notty_unix.output_image_size ~clear (fun (w, _) ->
-      let i1 = I.string c name in
-      let i2 = I.strf ~attr:c "[%04s]" stat in
-      I.(i1 <|> void (min w 80 - width i1 - width i2) 1 <|> i2));
+  let show_status_line ?(clear=false) stat =
+    Printf.printf "%s\n" stat;
     if clear then print_newline ();
     flush stdout in
   let ppf = Format.std_formatter in
@@ -368,15 +364,15 @@ let run_test ~mode ~silent ?(verbose=false) (Test (name, gens, f)) =
       match classify_status status with
       | `Pass ->
          show_status_line
-           ~clear:true ~c:Notty.A.(fg green) "PASS";
+           ~clear:true "PASS";
          if verbose then pp ppf "%a@." print_status status
       | `Fail ->
          show_status_line
-           ~clear:true ~c:Notty.A.(fg lightred ++ st bold) "FAIL";
+           ~clear:true "FAIL";
          pp ppf "%a@." print_status status;
       | `Bad ->
          show_status_line
-           ~clear:true ~c:Notty.A.(fg yellow) "BAD";
+           ~clear:true "BAD";
          pp ppf "%a@." print_status status;
     end;
   status


### PR DESCRIPTION
notty currently doesn't build on OCaml > 4.05.  I love color as much as the next `afl-fuzz` user, but I also love being able to compile things.