### PR TITLE
remove some stuff from xmldiff example

### DIFF
--- a/examples/test_xmldiff.ml
+++ b/examples/test_xmldiff.ml
@@ -1,21 +1,7 @@
-module Op = struct
-type ('k, 'res) gens = ('k, 'res) Crowbar.gens =
-  | [] : ('res, 'res) gens
-  | (::) : 'a Crowbar.gen * ('k, 'res) gens -> ('a -> 'k, 'res) gens
-
-(* re-export stdlib's list
-   We only want to override [] syntax in the argument to Map *)
-type nonrec +'a list = 'a list = [] | (::) of 'a * 'a list
-
-end
-
-module C = Crowbar
-open Op
-let ident = C.choose [C.const "a"; C.const "b"; C.const "c"]
-let elem_name = C.map [ident] (fun s -> ("", s))
-
-
 open Crowbar
+
+let ident = choose [const "a"; const "b"; const "c"]
+let elem_name = map [ident] (fun s -> ("", s))
 
 
 let attrs =


### PR DESCRIPTION
`module Op` looks like a vestigial thing that can be removed since the definition of `gens` in `crowbar.mli` now matches it; can you confirm or deny, @stedolan ?

I also removed what looked like some inessential weirdness in defining `ident` and `elem_name`, but let me know if I'm misunderstanding something subtle.