### PR TITLE
Add a fix combinator for easily defining recursive generators

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -28,6 +28,11 @@ type nonrec +'a list = 'a list = [] | (::) of 'a * 'a list
 
 let unlazy f =
   Join (Primitive (fun _ -> Lazy.force f))
+
+let fix f =
+  let rec lazygen = lazy (f (unlazy lazygen)) in
+  unlazy lazygen
+
 let map gens f = Map (gens, f)
 
 let const x = map [] x

--- a/src/crowbar.mli
+++ b/src/crowbar.mli
@@ -18,6 +18,7 @@ val join : 'a gen gen -> 'a gen
 val bind : 'a gen -> ('a -> 'b gen) -> 'b gen
 
 val unlazy : 'a gen Lazy.t -> 'a gen
+val fix : ('a gen -> 'a gen) -> 'a gen
 
 val const : 'a -> 'a gen
 val choose : 'a gen list -> 'a gen


### PR DESCRIPTION
This is an attempt at defining a simple `fix` combinator, wrapping the use of lazy/unlazy for defining recursive generators. 

It does not covers the case of mutually recursive definitions, but should already be useful (e.g. for porting the tests to the current API -- coming in the next PR).