### PR TITLE
try slightly harder to fix nonterminating size policy

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -204,7 +204,9 @@ let rec generate : type a . int -> state -> a gen -> a * unit printer =
        | Error (e, bt) -> raise (GenFailed (e, bt, pvs))
      end
   | Option gen ->
-     if read_bool input then
+     if size < 1 then
+       None, fun ppf () -> pp ppf "None"
+     else if read_bool input then
        let v, pv = generate size input gen in
        Some v, fun ppf () -> pp ppf "Some (%a)" pv ()
      else


### PR DESCRIPTION
This is a rebase and continuation of #18 .

You can see this branch in action on the ocaml-test-stdlib tests [here](https://travis-ci.org/yomimono/ocaml-test-stdlib/builds/314124729), where the tests running in a 4.05.0 environment [fail with a stack overflow](https://travis-ci.org/yomimono/ocaml-test-stdlib/jobs/314124730) but the tests in 4.06.0 [succeed](https://travis-ci.org/yomimono/ocaml-test-stdlib/jobs/314124731) (meaning they run for 25 minutes under afl-fuzz without finding any crashes).

I've generally been in a 4.05.0 universe when using ocaml-test-omp, which may explain (shallowly - I don't understand why 4.05.0's performance would be dramatically worse) why various fixes worked for @stedolan but not me.