### PR TITLE
nicer command-line behavior using cmdliner

### DIFF
--- a/crowbar.opam
+++ b/crowbar.opam
@@ -14,6 +14,7 @@ depends: [
   "ocamlfind"
   "jbuilder" {build}
   "ocplib-endian"
+  "cmdliner"
   "afl-persistent" {>= "1.1"}
   "calendar" {test}
   "xmldiff" {test}

--- a/src/jbuild
+++ b/src/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name crowbar)
   (public_name crowbar)
-  (libraries (ocplib-endian afl-persistent str))))
+  (libraries (cmdliner ocplib-endian afl-persistent str))))


### PR DESCRIPTION
Help the user of `crowbar` tests invoke the resulting binaries correctly by providing some `--help` documentation and failing more nicely.

@stedolan , this patch also removes the commented-out code at the bottom of `crowbar.ml`, which I keep thinking I already submitted PRs to delete, but I guess not?