### PR TITLE
Join

### DIFF
--- a/examples/serializer/jbuild
+++ b/examples/serializer/jbuild
@@ -1,0 +1,11 @@
+(jbuild_version 1)
+
+(executable
+ ((name test_serializer)
+  (libraries (crowbar))
+))
+
+(alias
+ ((name runtest)
+  (action (run ${exe:test_serializer.exe}))
+))

--- a/examples/serializer/serializer.ml
+++ b/examples/serializer/serializer.ml
@@ -1,0 +1,34 @@
+type data =
+  | Datum of string
+  | Block of header * data list
+and header = string
+
+type _ ty =
+  | Int : int ty
+  | Bool : bool ty
+  | Prod : 'a ty * 'b ty -> ('a * 'b) ty
+  | List : 'a ty -> 'a list ty
+
+let rec pp_ty : type a . _ -> a ty -> unit = fun ppf ->
+  let printf fmt = Format.fprintf ppf fmt in
+  function
+  | Int -> printf "Int"
+  | Bool -> printf "Bool"
+  | Prod(ta, tb) -> printf "Prod(%a,%a)" pp_ty ta pp_ty tb
+  | List t -> printf "List(%a)" pp_ty t
+
+let rec serialize : type a . a ty -> a -> data = function
+  | Int -> fun n -> Datum (string_of_int n)
+  | Bool -> fun b -> Datum (string_of_bool b)
+  | Prod (ta, tb) -> fun (va, vb) ->
+    Block("pair", [serialize ta va; serialize tb vb])
+  | List t -> fun vs ->
+    Block("list", List.map (serialize t) vs)
+
+let rec deserialize : type a . a ty -> data -> a = function[@warning "-8"]
+  | Int -> fun (Datum s) -> int_of_string s
+  | Bool -> fun (Datum s) -> bool_of_string s
+  | Prod (ta, tb) -> fun (Block("pair", [sa; sb])) ->
+    (deserialize ta sa, deserialize tb sb)
+  | List t -> fun (Block("list", ss)) ->
+    List.map (deserialize t) ss

--- a/examples/serializer/test_serializer.ml
+++ b/examples/serializer/test_serializer.ml
@@ -1,0 +1,47 @@
+open Crowbar
+
+module S = Serializer
+
+type any_ty = Any : 'a S.ty -> any_ty
+
+let ty_gen =
+  with_printer (fun ppf (Any t)-> S.pp_ty ppf t) @@
+  fix (fun ty_gen -> choose [
+    const (Any S.Int);
+    const (Any S.Bool);
+    map [ty_gen; ty_gen] (fun (Any ta) (Any tb) ->
+      Any (S.Prod (ta, tb)));
+    map [ty_gen] (fun (Any t) -> Any (List t));
+  ])
+
+let prod_gen ga gb = map [ga; gb] (fun va vb -> (va, vb))
+
+let rec gen_of_ty : type a . a S.ty -> a gen = function
+  | S.Int -> int
+  | S.Bool -> bool
+  | S.Prod (ta, tb) -> prod_gen (gen_of_ty ta) (gen_of_ty tb)
+  | S.List t -> list (gen_of_ty t)
+
+type pair = Pair : 'a S.ty * 'a -> pair
+
+(* The generator for the final value, [gen_of_ty t], depends on the
+   generated type representation, [t]. This dynamic dependency cannot
+   be expressed with [map], it requires [dynamic_bind]. *)
+let pair_gen : pair gen =
+  dynamic_bind ty_gen @@ fun (Any t) ->
+  map [gen_of_ty t] (fun v -> Pair (t, v))
+
+let rec printer_of_ty : type a . a S.ty -> a printer = function
+  | S.Int -> pp_int
+  | S.Bool -> pp_bool
+  | S.Prod (ta, tb) -> (fun ppf (a, b) ->
+      pp ppf "(%a, %a)" (printer_of_ty ta) a (printer_of_ty tb) b)
+  | S.List t -> pp_list (printer_of_ty t)
+
+let check_pair (Pair (t, v)) =
+  let data = S.serialize t v in
+  match S.deserialize t data with
+  | exception _ -> fail "incorrect deserialization"
+  | v' -> check_eq ~pp:(printer_of_ty t) v v'
+
+let () = add_test ~name:"pairs" [pair_gen] check_pair

--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -9,11 +9,11 @@ type state =
 
 type 'a printer = Format.formatter -> 'a -> unit
 
-
 type 'a gen =
   | Const of 'a
   | Choose of 'a gen list
   | Map : ('f, 'a) gens * 'f -> 'a gen
+  | Bind : 'a gen * ('a -> 'b gen) -> 'b gen
   | Option : 'a gen -> 'a option gen
   | List : 'a gen -> 'a list gen
   | List1 : 'a gen -> 'a list gen
@@ -33,6 +33,8 @@ let fix f =
   unlazy lazygen
 
 let map gens f = Map (gens, f)
+
+let dynamic_bind m f = Bind(m, f)
 
 let const x = map [] x
 let choose gens = Choose gens
@@ -173,12 +175,12 @@ let range n =
 exception GenFailed of exn * Printexc.raw_backtrace * unit printer
 
 let minimize_depth : type a . a gen list -> a gen list = fun gens ->
-  let only_branchless = List.filter (function
-      | Const _ -> true | _ -> false) gens in
-  let without_branchy = List.filter (function Map _ | Choose _ -> false
-                                            | _ -> true) gens in
-  let without_maps = List.filter (function Map _ -> false | _ -> true) gens in
-  match only_branchless, without_branchy, without_maps with
+  let only p = List.filter p gens in
+  let without p = List.filter (fun v -> not (p v)) gens in
+  let branchless = function | Const _ -> true | _ -> false in
+  let branchy = function | Map _ | Bind _ | Choose _ -> true | _ -> false in
+  let complex = function | Map _ | Bind _ -> true | _ -> false in
+  match only branchless, without branchy, without complex with
   | x::xs, _    , _     -> x :: xs
   | [],    x::xs, _     -> x :: xs
   | [],    [],    x::xs -> x :: xs
@@ -214,6 +216,10 @@ let rec generate : type a . int -> state -> a gen -> a * unit printer =
        | Ok v -> v, pvs
        | Error (e, bt) -> raise (GenFailed (e, bt, pvs))
      end
+  | Bind (m, f) ->
+     let index, pv_index = generate (size - 1) input m in
+     let a, pv = generate (size - 1) input (f index) in
+     a, (fun ppf () -> pp ppf "(%a) => %a" pv_index () pv ())
   | Option gen ->
      if size < 1 then
        None, fun ppf () -> pp ppf "None"

--- a/src/crowbar.mli
+++ b/src/crowbar.mli
@@ -123,6 +123,35 @@ val with_printer : 'a printer -> 'a gen -> 'a gen
     calling [check_eq] without [pp] set, [printer] will be used to print the
     failing test case. *)
 
+val dynamic_bind : 'a gen -> ('a -> 'b gen) -> 'b gen
+(** [dynamic_bind gen f] is a monadic bind, it allows to express the
+   generation of a value whose generator itself depends on
+   a previously generated value. This is in contrast with [map gen f],
+   where no further generation happens in [f] after [gen] has
+   generated an element.
+
+   An typical example where this sort of dependencies is required is
+   a serialization library exporting combinators letting you build
+   values of the form ['a serializer]. You may want to test this
+   library by first generating a pair of a serializer and generator
+   ['a serializer * 'a gen] for arbitrary ['a], and then generating
+   values of type ['a] depending on the (generated) generator to test
+   the serializer. There is such an example in the
+   [examples/serializer/] directory of the Crowbar implementation.
+
+   Because the structure of a generator built with [dynamic_bind] is
+   opaque/dynamic (it depends on generated values), the Crowbar
+   library cannot analyze its statically
+   (without generating anything) -- the generator is opaque to the
+   library, hidden in a function. In particular, many optimizations or
+   or fuzzing techniques based on generator analysis are
+   impossible. As a client of the library, you should avoid
+   [dynamic_bind] whenever it is not strictly required to express
+   a given generator, so that you can take advantage of these features
+   (present or future ones). Use the least powerful/complex
+   combinators that suffice for your needs.
+*)
+
 (** {1:printing Printing } *)
 
 (* Format.fprintf, renamed *)


### PR DESCRIPTION
I would like to test a library that provides type-directed combinators (`'a encoding`) for serialization and deserialization. The natural way to crowbar this is to build a generator of pairs at the type (`'a gen * 'a encoding`), and then test that any generated value will pass serialization->deserialization unchanged. 

Dealing with such nested generators requires monadic structure, either with a `join : 'a gen gen -> 'a gen` function or a more traditional `bind`, which are currently absent from the Crowbar interface. This PR adds those two functions, plus an example demonstrating this use-case (testing type-directed combinators for serialization) in a toy case.

Remarks:
- I understand that people tend to over-use the monadic structure when it is available, combining `bind` and `return` when they should have used `map` instead (which gives more freedom to the implementor by making it possible to statically explore the generator's shape). I could try to write a comment to encourage people not to use these new functions unless they are dealing with nested generators, or I could remove `bind` and expose only `join`, which is more explicit. (I started with only `join`, but it turns out that my example is nicer with `bind`.)
- I was a bit confused by the `size` parameter in the `generate` function: a comment explaining what it is doing at the top would have been nice (right now there is a comment in the middle of the function that looks (understandably) confused itself). I just use `size - 1` in my two recursive calls, which ensures termination but may not be the right thing either. (Maybe `(size / 2)` in both cases?) Explaining reasons for choosing something could be nice. (For example, if there are several recursive calls, can we recommend that the sum of their parameters equal the initial size value?).
- I was also a bit confused by what the printer is supposed to do, so I improvised the idea that it was just for debugging, and chose `(%a) => %a` (first the generated generator, then the generated value).
- I adapted the (also lacking a specified purpose) `minimize_depths` function by considering that `Join` should be filtered out whenever `Map` is filtered out. One could even consider adding a fourth filtering category where Map is allowed, but Join is not.