### PR TITLE
New functions ffail and pp_option. Do not quote message in fail.

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -68,6 +68,11 @@ let pp_string ppf s = pp ppf "\"%s\"" (String.escaped s)
 let pp_list pv ppf l =
   pp ppf "@[<hv 1>[%a]@]"
      (Format.pp_print_list ~pp_sep:(fun ppf () -> pp ppf ";@ ") pv) l
+let pp_option pv ppf = function
+  | None ->
+      Format.fprintf ppf "None"
+  | Some x ->
+      Format.fprintf ppf "(Some %a)" pv x
 
 exception BadTest of string
 exception FailedTest of unit printer

--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -321,6 +321,9 @@ and gen_apply :
 
 let fail s = raise (FailedTest (fun ppf () -> pp_string ppf s))
 
+let failf format =
+  Format.kasprintf fail format
+
 let check = function
   | true -> ()
   | false -> raise (FailedTest (fun ppf () -> pp ppf "check false"))

--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -319,7 +319,7 @@ and gen_apply :
   v, pvs
 
 
-let fail s = raise (FailedTest (fun ppf () -> pp_string ppf s))
+let fail s = raise (FailedTest (fun ppf () -> pp ppf "%s" s))
 
 let failf format =
   Format.kasprintf fail format

--- a/src/crowbar.mli
+++ b/src/crowbar.mli
@@ -210,6 +210,11 @@ val nonetheless : 'a option -> 'a
 val fail : string -> 'a
 (** [fail message] generates a test failure and prints [message]. *)
 
+val failf : ('a, Format.formatter, unit, _) format4 -> 'a
+(** [failf format ...] generates a test failure and prints the message
+    specified by the format string [format] and the following arguments.
+    It is set up so that [%a] calls for an ['a printer] and an ['a] value. *)
+
 (** {2:asserting Asserting Properties} *)
 
 val check : bool -> unit

--- a/src/crowbar.mli
+++ b/src/crowbar.mli
@@ -180,6 +180,7 @@ val pp_float : float printer
 val pp_bool : bool printer
 val pp_string : string printer
 val pp_list : 'a printer -> 'a list printer
+val pp_option : 'a printer -> 'a option printer
 
 (** {1:testing Testing} *)
 


### PR DESCRIPTION
`pp_option` should be uncontroversial.

`ffail` seems useful; it works like `fail`, but accepts a format string and extra arguments instead of just a string. One might wish to call it just `fail`, but that would technically be an incompatible change, because not every string can be safely re-interpreted as a format string.

Finally, I propose changing `fail` to not quote/escape the message. This looks nicer.
