### PR TITLE
Fix typo in [choose_int]: 100 should be 0x100.

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -190,7 +190,7 @@ let choose_int n state =
   assert (n > 0);
   if n = 1 then
     0
-  else if (n < 100) then
+  else if (n < 0x100) then
     read_byte state mod n
   else if (n < 0x1000000) then
     Int32.(to_int (abs (rem (read_int32 state) (of_int n))))

--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -190,7 +190,7 @@ let choose_int n state =
   assert (n > 0);
   if n = 1 then
     0
-  else if (n < 0x100) then
+  else if (n <= 0x100) then
     read_byte state mod n
   else if (n < 0x1000000) then
     Int32.(to_int (abs (rem (read_int32 state) (of_int n))))


### PR DESCRIPTION
This should allow the input data to be more efficiently exploited.