### PR TITLE
Add a shuffled list generator

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -210,8 +210,8 @@ let range ?(min=0) n =
 let shuffle l =
   match l with
   | []
-  | [_] -> Const l
-  | [a; b] -> Choose [Const [b; a]; Const [a; b]]
+  | [_] -> const l
+  | [a; b] -> Choose [const [b; a]; const [a; b]]
   | _ ->
     let state = Array.of_list l in
     let length = Array.length state in
@@ -222,7 +222,7 @@ let shuffle l =
     in
     let rec gen i =
       if i = 0 then
-        Const (Array.to_list state)
+        const (Array.to_list state)
       else
         dynamic_bind (range (i + 1)) (fun j -> swap i j; gen (i - 1))
     in

--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -207,6 +207,27 @@ let range ?(min=0) n =
     raise (Invalid_argument "Crowbar.range: argument min must be positive or null");
   Print (pp_int, Primitive (fun s -> min + choose_int n s))
 
+let shuffle l =
+  match l with
+  | []
+  | [_] -> Const l
+  | [a; b] -> Choose [Const [b; a]; Const [a; b]]
+  | _ ->
+    let state = Array.of_list l in
+    let length = Array.length state in
+    let swap i j =
+      let tmp = state.(i) in
+      state.(i) <- state.(j);
+      state.(j) <- tmp
+    in
+    let rec gen i =
+      if i = 0 then
+        Const (Array.to_list state)
+      else
+        dynamic_bind (range (i + 1)) (fun j -> swap i j; gen (i - 1))
+    in
+    gen (length - 1) 
+
 exception GenFailed of exn * Printexc.raw_backtrace * unit printer
 
 let minimize_depth : type a . a gen list -> a gen list = fun gens ->

--- a/src/crowbar.mli
+++ b/src/crowbar.mli
@@ -134,6 +134,9 @@ val list1 : 'a gen -> 'a list gen
 (** [list1 gen] makes non-empty list generators. For potentially empty lists,
     use {!list}.*)
 
+val shuffle : 'a list -> 'a list gen
+(** [shuffle l] generates random permutations of [l] using the Fisher-Yates algorithm *)
+
 val concat_gen_list : string gen -> string gen list -> string gen
 (** [concat_gen_list sep l] concatenates a list of string gen [l] inserting the
     separator [sep] between each *)


### PR DESCRIPTION
This PR adds a `shuffle: 'a list -> 'a list gen` generator using Fisher-Yates algorithm.

I tested it with a toy program and it seems to work pretty well!

Let me know what you think!