### PR TITLE
Add char generator

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -66,6 +66,7 @@ let pp_int32 ppf n = pp ppf "%s" (Int32.to_string n)
 let pp_int64 ppf n = pp ppf "%s" (Int64.to_string n)
 let pp_float ppf f = pp ppf "%f" f
 let pp_bool ppf b = pp ppf "%b" b
+let pp_char ppf c = pp ppf "%c" c
 let pp_string ppf s = pp ppf "\"%s\"" (String.escaped s)
 let pp_list pv ppf l =
   pp ppf "@[<hv 1>[%a]@]"
@@ -167,6 +168,8 @@ let float = Print (pp_float, Primitive (fun src ->
   let off = getbytes src 8 in
   EndianBytes.LittleEndian.get_double src.buf off))
 
+let char = Print (pp_char, Primitive read_char)
+
 (* maybe print as a hexdump? *)
 let bytes = Print (pp_string, Primitive (fun src ->
   (* null-terminated, with '\001' as an escape code *)
@@ -225,7 +228,7 @@ let shuffle l =
       else
         dynamic_bind (range (i + 1)) (fun j -> swap i j; gen (i - 1))
     in
-    gen (length - 1) 
+    gen (length - 1)
 
 exception GenFailed of exn * Printexc.raw_backtrace * unit printer
 

--- a/src/crowbar.mli
+++ b/src/crowbar.mli
@@ -50,6 +50,9 @@ val int64 : Int64.t gen
 val float : float gen
 (** [float] generates a double-precision floating-point number. *)
 
+val char : char gen
+(** [char] generates a char. *)
+
 val bytes : string gen
 (** [bytes] generates a string of arbitrary length (including zero-length strings).  *)
 


### PR DESCRIPTION
This PR adds a `char : char gen` generator.
While one can easily get it out of a `string gen` using `map`, I think it's nice to have basic types directly available.