### PR TITLE
Be compatible with < 4.10.0

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -42,7 +42,7 @@ let map (type f) (type a) (gens : (f, a) gens) (f : f) =
 let dynamic_bind m f = {strategy = Bind(m, f); small_examples = [] }
 
 let const x = map [] x
-let choose gens = { strategy = Choose gens; small_examples = List.concat_map (fun x -> x.small_examples) gens }
+let choose gens = { strategy = Choose gens; small_examples = Stdlib.List.concat_map (fun x -> x.small_examples) gens }
 let option gen = { strategy = Option gen; small_examples = [None] }
 let list gen = { strategy = List gen; small_examples = [[]] }
 let list1 gen = { strategy = List1 gen; small_examples = List.map (fun x -> [x]) gen.small_examples }

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library
  (public_name crowbar)
- (libraries cmdliner ocplib-endian afl-persistent str))
+ (libraries stdlib-shims cmdliner ocplib-endian afl-persistent str))


### PR DESCRIPTION
`List.concat_map` was introduced by OCaml 4.10.0, this fix add a new dependency `stdlib-shims` to still be compatible with `4.08.0`.