### PR TITLE
With seed as cli parameter

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -354,7 +354,7 @@ let check_eq ?pp:pv ?cmp ?eq a b =
     | Some eq, _ -> eq a b
     | None, Some cmp -> cmp a b = 0
     | None, None ->
-       Pervasives.compare a b = 0 in
+       Stdlib.compare a b = 0 in
   if pass then
     ()
   else


### PR DESCRIPTION
This PR adds a CLI parameter (`-s`/`--seed`) to make the quickcheck mode fully deterministic.

Note that the current state is mostly deterministic: two consecutive runs derive the same original seed from the global `Random` PRNG. However, linked libraries can change the PRNG state:
- A linked library may be calling `Random.self_init` which makes the tests non-deterministic.
- Updating a dependency may introduce or remove calls to `Random.int`, changing the determinism.

This PR is not yet tested. I wanted to get a quick mood check before putting significant effort in: Is this change or one like it likely to be merged? Is there interest for such a feature? Any comments on the user interface?