### PR TITLE
Initialize Random to work better with OCaml 5.0

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -1,3 +1,6 @@
+(* Fix for OCaml 5.0 *)
+let () = Random.init 42
+
 type src = Random of Random.State.t | Fd of Unix.file_descr
 type state =
   {


### PR DESCRIPTION
Same fix as applied here: https://github.com/mirage/mrmime/pull/92