### PR TITLE
add a Syntax module

### DIFF
--- a/src/crowbar.ml
+++ b/src/crowbar.ml
@@ -592,3 +592,9 @@ let () =
                                  infinity $ const (List.rev t)) in
         exit @@ Cmdliner.Cmd.eval' ~catch:false (Cmdliner.Cmd.v crowbar_info cmd)
     )
+
+module Syntax = struct
+  let ( let* ) = dynamic_bind
+  let ( let+ ) gen map_fn = map [ gen ] map_fn
+  let ( and+ ) = pair
+end

--- a/src/crowbar.mli
+++ b/src/crowbar.mli
@@ -249,3 +249,20 @@ val check_eq : ?pp:('a printer) -> ?cmp:('a -> 'a -> int) -> ?eq:('a -> 'a -> bo
     If [pp] is not provided, a best-effort printer will be generated from the
     printers for primitive generators and any printers registered with
     [with_printer] and used. *)
+
+
+(** {1:syntax Syntax module } *)
+module Syntax : sig
+    val ( let+ ) : 'a gen -> ('a -> 'b) -> 'b gen
+    (** [let+ x = gen in e] is equivalent to [map [ gen ] (fun x -> e)]. *)
+
+    val ( let* ) : 'a gen -> ('a -> 'b gen) -> 'b gen
+    (** Equivalent to {!dynamic_bind}.
+        [let* x = gen in e] is equivalent to [dynamic_bind gen (fun x -> e)]. *)
+
+    val ( and+ ) : 'a gen -> 'b gen -> ('a * 'b) gen
+    (** Equivalent to {!pair}.
+        [let+ x = gen_x and+ y = gen_y and+ z = gen_z in e]
+        is equivalent to
+        [ map [pair (pair gen_x gen_y) gen_z)] (fun ((x, y), z) -> e) ]. *)
+end


### PR DESCRIPTION
Hi @stedolan,

I simply defined `let*` as `dynamic_bind` and `let+` as `map`. They're in a `Syntax` module to avoid potential conflicts.

I use them a lot as it sometimes makes the code much more easy to follow and I guess I'm not the only one.