### PR TITLE
add array and array1

### DIFF
--- a/src/crowbar.mli
+++ b/src/crowbar.mli
@@ -140,6 +140,14 @@ val list1 : 'a gen -> 'a list gen
 (** [list1 gen] makes non-empty list generators. For potentially empty lists,
     use {!list}.*)
 
+val array : 'a gen -> 'a array gen
+(** [array gen] makes a generator for arrays using [gen]. Arrays may be empty; for
+    non-empty arrays, use {!array1}. *)
+
+val array1 : 'a gen -> 'a array gen
+(** [array1 gen] makes non-empty array generators. For potentially empty arrays,
+    use {!array}.*)
+
 val shuffle : 'a list -> 'a list gen
 (** [shuffle l] generates random permutations of [l]. *)
 


### PR DESCRIPTION
Hi,

I added `array` and `array1` as I was tired of writing `let* x = list y in let x = Array.of_list x`.

I copy-pasted the new `pp_print_iter` from the Stdlib and redefined `pp_list` with it (and added `pp_array`).

The code for generating the arrays is calling `list` and `list1` and then converting them to arrays. It's probably not the more efficient way to write it but the diff is short and it's obviously correct.